### PR TITLE
chore: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler"
+    directory: "/"
+    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "daily"


### PR DESCRIPTION
only update version in gemfile when necessary.